### PR TITLE
Support custom names for chunk and imports file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,20 @@ module.exports = {
   },
   plugins: [
     new ExtractTextPlugin('styles.css'),
-    new CSSSplitWebpackPlugin({size: 4000, imports: true}),
+    new CSSSplitWebpackPlugin({size: 4000}),
   ],
 };
-
 ```
+
+The following configuration options are available:
+
+**size**: `default: 4000` The maximum number of CSS rules allowed in a single file. To make things work with IE this value should be somewhere around `4000`.
+
+**imports**: `default: false` If you originally built your app to only ever consider using one CSS file then this flag is for you. It creates an additional CSS file that imports all of the split files. You pass `true` to turn this feature on, or a string with the name you'd like the generated file to have.
+
+**filename**: `default: "[name]-[part].[ext]"` Control how the split files have their names generated. The default uses the parent's filename and extension, but adds in the part number.
+
+**preserve**: `default: false`. Keep the original unsplit file as well. Sometimes this is desirable if you want to target a specific browser (IE) with the split files and then serve the unsplit ones to everyone else.
 
 [webpack]: http://webpack.github.io/
 [herp]: https://github.com/ONE001/css-file-rules-webpack-separator

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "webpack": "^1.13.0"
   },
   "dependencies": {
+    "loader-utils": "^0.2.15",
     "postcss": "^5.0.19"
   },
   "peerDependencies": {

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -67,4 +67,25 @@ describe('CSSSplitWebpackPlugin', () => {
         .to.not.contain('styles.css');
     });
   });
+  it('should allow customization of import name', () => {
+    return webpack({size: 3, imports: 'potato.css'}).then((stats) => {
+      expect(stats).to.not.be.null;
+      expect(stats.assetsByChunkName).to.have.property('main')
+        .to.contain('potato.css');
+    });
+  });
+  it('should allow preservation of the original unsplit file', () => {
+    return webpack({size: 3, imports: false, preserve: true}).then((stats) => {
+      expect(stats).to.not.be.null;
+      expect(stats.assetsByChunkName).to.have.property('main')
+        .to.contain('styles.css');
+    });
+  });
+  it('should give sensible names by default', () => {
+    return webpack({size: 3, imports: true, preserve: true}).then((stats) => {
+      expect(stats).to.not.be.null;
+      expect(stats.assetsByChunkName).to.have.property('main')
+        .to.contain('styles-split.css');
+    });
+  });
 });


### PR DESCRIPTION
Previously the name of both the split files _and_ the imports file were fixed. For split files they were just the name of the source asset with a `-i` tacked on; for import files they always overwrote the original asset. Both of these are now customizable using the standard webpack name interpolator; you get things like `[name]`, `[ext]` and so forth. For the split files you also get an additional `[part]` value that signifies the current part.

Additionally, this allows for one to generate both the split files and imports _as well as_ keep the original unsplit files. This may be desirable in cases where you only wish to serve the split files to a specific target (i.e. IE) and use the unsplit files everywhere else.