### PR TITLE
Bump version to v0.2.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-split-webpack-plugin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "license": "CC0-1.0",
   "repository": "metalabdesign/css-split-webpack-plugin",


### PR DESCRIPTION
Technically _not_ a breaking change, but significant enough and new enough that it's getting a major.

🚢 