### PR TITLE
Use `webpack-sources`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   },
   "dependencies": {
     "loader-utils": "^0.2.15",
-    "postcss": "^5.0.19"
+    "postcss": "^5.0.19",
+    "webpack-sources": "^0.1.3"
   },
   "peerDependencies": {
     "webpack": ">=1"

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import postcss from 'postcss';
 import chunk from './chunk';
-import SourceMapSource from 'webpack/lib/SourceMapSource';
+import {SourceMapSource} from 'webpack-sources';
 import RawSource from 'webpack/lib/RawSource';
 import {interpolateName} from 'loader-utils';
 


### PR DESCRIPTION
Adds compatibility to `webpack@2`. Resolves https://github.com/metalabdesign/css-split-webpack-plugin/issues/10.