### PR TITLE
Allow splitting on `emit` event.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ The following configuration options are available:
 
 **preserve**: `default: false`. Keep the original unsplit file as well. Sometimes this is desirable if you want to target a specific browser (IE) with the split files and then serve the unsplit ones to everyone else.
 
+**defer**: `default: 'false'`. You can pass `true` here to cause this plugin to split the CSS on the `emit` phase. Sometimes this is needed if you have other plugins that operate on the CSS also in the emit phase. Unfortunately by doing this you potentially lose chunk linking and source maps. Use only when necessary.
+
 [webpack]: http://webpack.github.io/
 [herp]: https://github.com/ONE001/css-file-rules-webpack-separator
 [postcss]: https://github.com/postcss/postcss

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -133,10 +133,36 @@ describe('CSSSplitWebpackPlugin', () => {
       expect(files).to.not.have.property('styles-1.css.map');
     })
   );
-
   it('should fail with bad imports', () => {
     expect(() =>
       new CSSSplitWebpackPlugin({imports: () => {}})
     ).to.throw(TypeError);
+  });
+  describe('deferred emit', () => {
+    it('should split css files when necessary', (done) => {
+      webpack({size: 3, defer: true}).then(({stats, files}) => {
+        expect(stats.assetsByChunkName)
+          .to.have.property('main')
+          .to.contain('styles-1.css')
+          .to.contain('styles-2.css');
+        expect(files).to.have.property('styles-1.css');
+        expect(files).to.have.property('styles-2.css');
+        expect(files).to.have.property('styles.css.map');
+        done();
+      });
+    });
+    it('should ignore files that do not need splitting', (done) => {
+      webpack({size: 10, defer: true}).then(({stats, files}) => {
+        expect(stats.assetsByChunkName)
+          .to.have.property('main')
+          .to.contain('styles.css')
+          .to.not.contain('styles-1.css')
+          .to.not.contain('styles-2.css');
+        expect(files).to.have.property('styles.css');
+        expect(files).to.not.have.property('styles-1.css');
+        expect(files).to.not.have.property('styles-2.css');
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
Add a new flag called `defer`. You can pass `true` here to cause this plugin to split the CSS on the `emit` phase. Sometimes this is needed if you have other plugins that operate on the CSS also in the emit phase. Unfortunately by doing this you potentially lose chunk linking and source maps. Use only when necessary.