### PR TITLE
[patch] fix map undefined issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -119,7 +119,7 @@ export default class CSSSplitWebpackPlugin {
           return new SourceMapSource(
             css,
             name(i),
-            map.toString()
+            map && map.toString()
           );
         }),
       });


### PR DESCRIPTION
`optimize-css-assets-webpack-plugin` delegates to the CSS processor (cssnano as default). We have loaders for the styles file and they got compiled and minified by cssnano (with PostCSS). cssnano will remove the soucemaps.

Since optimize happens first and css split comes into after, at that time the sourcemap would be undefined.