### PR TITLE
Handle case where there are no source maps.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5505,6 +5505,16 @@
         "is-buffer": "1.1.6"
       }
     },
+    "last-call-webpack-plugin": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/last-call-webpack-plugin/-/last-call-webpack-plugin-2.1.2.tgz",
+      "integrity": "sha512-CZc+m2xZm51J8qSwdODeiiNeqh8CYkKEq6Rw8IkE4i/4yqf2cJhjQPsA6BtAV970ePRNhwEOXhy2U5xc5Jwh9Q==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4",
+        "webpack-sources": "1.0.2"
+      }
+    },
     "lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
@@ -6305,6 +6315,16 @@
           "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         }
+      }
+    },
+    "optimize-css-assets-webpack-plugin": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-3.2.0.tgz",
+      "integrity": "sha512-Fjn7wyyadPAriuH2DHamDQw5B8GohEWbroBkKoPeP+vSF2PIAPI7WDihi8WieMRb/At4q7Ea7zTKaMDuSoIAAg==",
+      "dev": true,
+      "requires": {
+        "cssnano": "3.10.0",
+        "last-call-webpack-plugin": "2.1.2"
       }
     },
     "optionator": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "less-loader": "^2.2.3",
     "memory-fs": "^0.3.0",
     "mocha": "^2.4.5",
+    "optimize-css-assets-webpack-plugin": "^3.2.0",
     "style-loader": "^0.13.1",
     "webpack": "^1.13.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ export default class CSSSplitWebpackPlugin {
     const input = asset.sourceAndMap ? asset.sourceAndMap() : {
       source: asset.source(),
     };
-    const name = (i) => this.options.filename({
+    const getName = (i) => this.options.filename({
       ...asset,
       content: input.source,
       file: key,
@@ -116,11 +116,14 @@ export default class CSSSplitWebpackPlugin {
       return Promise.resolve({
         file: key,
         chunks: result.chunks.map(({css, map}, i) => {
-          return new SourceMapSource(
+          const name = getName(i);
+          const result = map ? new SourceMapSource(
             css,
-            name(i),
+            name,
             map.toString()
-          );
+          ) : new RawSource(css);
+          result.name = name;
+          return result;
         }),
       });
     });
@@ -141,8 +144,8 @@ export default class CSSSplitWebpackPlugin {
           }
           // Inject the new files into the chunk.
           entry.chunks.forEach((file) => {
-            assets[file._name] = file;
-            chunk.files.push(file._name);
+            assets[file.name] = file;
+            chunk.files.push(file.name);
           });
           const content = entry.chunks.map((file) => {
             return `@import "${publicPath}/${file._name}";`;


### PR DESCRIPTION
This turns out to be really hard to do in practice. Generally speaking any time you use `ExtractTextPlugin` you get a `ConcatSource` which always has `sourceAndMap` available. The only case you don't get a source map is when another plugin generates a CSS file that uses `RawSource` or something similar. One such plugin is `optimize-css-assets-webpack-plugin` when you don't tell the CSS processor to generate a source map (e.g. `cssProcessorOptions` has no `map` entry).

 ```
foo.styl -> foo.css -> ExtractTextPlugin
bar.styl -> bar.css ---^
```

Everything goes into `ExtractTextPlugin` and that ALWAYS generates something with a source map, even if it’s an empty one. The issue here is your css optimizer; it goes:

 ```ExtractTextPlugin -> Optimizer -> Splitter```

And that kills everything.

Original PR from @didi0613 here: https://github.com/metalabdesign/css-split-webpack-plugin/pull/23 We just include a test in this one and a bit more of an investigation into why things happened the way they did.