### PR TITLE
Resolve from warnings on webpack 4

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,6 +109,7 @@ export default class CSSSplitWebpackPlugin {
       index: i,
     });
     return postcss([chunk(this.options)]).process(input.source, {
+      from: undefined,
       map: {
         prev: input.map,
       },


### PR DESCRIPTION
Resolves the warning:

```
Without `from` option PostCSS could generate wrong source map and will not find Browserslist config. Set it to CSS file path or to `undefined` to prevent this warning.
```